### PR TITLE
fix(url): apply review from copilot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,7 @@
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
         "remark-unwrap-images": "^4.0.1",
+        "server-only": "^0.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "tailwind-scrollbar-hide": "^4.0.0",
@@ -18860,6 +18861,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
     "remark-unwrap-images": "^4.0.1",
+    "server-only": "^0.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwind-scrollbar-hide": "^4.0.0",

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,8 +1,20 @@
+import 'server-only'
+
 /**
  * Get the base URL for the application
- * Handles different environments: Vercel, custom NEXTAUTH_URL, or localhost
+ *
+ * **Server-only function** - This function accesses process.env and must only be used
+ * in server contexts (Server Components, generateMetadata, API routes, etc.)
+ *
+ * Handles different environments:
+ * - Vercel: Uses VERCEL_URL (available at runtime)
+ * - Custom: Uses NEXTAUTH_URL if set
+ * - Development: Falls back to localhost:3000
+ *
+ * @returns The base URL for the application
  */
 export function getBaseUrl(): string {
+  // VERCEL_URL is only available at runtime on Vercel, not at build time
   const vercelUrl = process.env.VERCEL_URL
 
   if (vercelUrl) {
@@ -13,12 +25,20 @@ export function getBaseUrl(): string {
     return process.env.NEXTAUTH_URL
   }
 
+  // Fallback for local development
   return 'http://localhost:3000'
 }
 
 /**
  * Construct a full URL from a path
+ *
+ * **Server-only function** - Must only be used in server contexts
+ *
  * @param path - The path to append to the base URL (should start with /)
+ * @returns The full absolute URL
+ *
+ * @example
+ * getFullUrl('/posts/my-post') // => 'https://example.com/posts/my-post'
  */
 export function getFullUrl(path: string): string {
   const baseUrl = getBaseUrl()


### PR DESCRIPTION
The getBaseUrl() function accesses process.env which is not available during build time in client components or edge runtime. This will cause the metadata generation to fail or use incorrect values when the page is statically generated.