### PR TITLE
Simplify CI and update workflow docs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,69 +1,21 @@
 # GitHub Workflows
 
-This directory contains GitHub Actions workflows for CI/CD.
+## `ci.yml` — CI
 
-## Workflows
+Runs on pushes to `main` and pull requests targeting `main`.
 
-### `ci.yml` - CI/CD Pipeline
+### Jobs
 
-Runs on all pushes and pull requests to `dev`, `staging`, and `main` branches.
+- **`ci/tests`** — Lint, type-check, and run the Jest suite against a PostgreSQL service container.
+- **`ci/build`** — Generate the Prisma client and run `npm run build` to verify the Next.js production build.
 
-#### Jobs
+Both checks are required by branch protection on `main`.
 
-1. **`ci/tests`** (Required for all branches)
-   - Runs on: dev, staging, main
-   - Steps:
-     - Install dependencies
-     - Setup PostgreSQL test database
-     - Generate Prisma client
-     - Run ESLint
-     - Run TypeScript type checking
-     - Run tests
+### Deployments
 
-2. **`ci/build`** (Required for all branches)
-   - Runs on: dev, staging, main (all branches that deploy)
-   - Steps:
-     - Install dependencies
-     - Generate Prisma client
-     - Build Next.js application
-     - Verify build output
-   - **Why for all branches?** Ensures preview deployments don't fail due to build errors
+Deployments are handled by Vercel's native Git integration:
 
-#### Branch Protection Alignment
+- **Pull requests**: Vercel posts a preview URL as a check.
+- **Push to `main`**: Vercel deploys to production automatically.
 
-- **dev**: Requires `ci/tests` + `ci/build` status checks
-- **staging**: Requires `ci/tests` + `ci/build` status checks + 1 approval
-- **main**: Requires `ci/tests` + `ci/build` status checks (strict mode) + 2 approvals
-
-**Note:** All branches run both tests and build to ensure preview deployments succeed.
-
-#### Environment Variables Required
-
-The workflow uses placeholder values for CI builds. No secrets are required unless you want to:
-- Upload coverage reports (requires `CODECOV_TOKEN`)
-
-## Adding Tests
-
-To add actual tests, update `package.json`:
-
-```json
-{
-  "scripts": {
-    "test": "jest --ci --coverage"
-  }
-}
-```
-
-And install Jest:
-
-```bash
-npm install --save-dev jest @types/jest ts-jest
-```
-
-## Deployment
-
-Deployments are triggered by the CI/CD pipeline (GitHub Actions) after all required checks pass:
-- **Preview**: Triggered by the workflow on every commit/PR to dev, staging, or main
-- **Production**: Triggered by the workflow on main branch pushes after checks and approvals
-
-Automatic deployments by Vercel are disabled in `vercel.json`; all deployments are managed by the workflow.
+CI does not deploy. Branch protection on `main` ensures only PRs that pass `ci/tests` and `ci/build` can merge, so production never receives an untested commit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,18 @@
-name: CI/CD Pipeline
+name: CI
 
 on:
   push:
     branches:
-      - dev
-      - staging
       - main
   pull_request:
     branches:
-      - dev
-      - staging
       - main
 
-# Cancel in-progress runs for the same workflow + branch combination
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Tests job - required for all branches
   tests:
     name: ci/tests
     runs-on: ubuntu-latest
@@ -39,17 +33,14 @@ jobs:
           - 5432:5432
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - run: npm ci
 
       - name: Setup test database
         env:
@@ -58,11 +49,9 @@ jobs:
           npx prisma generate
           npx prisma db push
 
-      - name: Run linter
-        run: npm run lint
+      - run: npm run lint
 
-      - name: Run type check
-        run: npx tsc --noEmit
+      - run: npx tsc --noEmit
 
       - name: Run tests
         env:
@@ -71,27 +60,21 @@ jobs:
           NEXTAUTH_SECRET: test-secret-key-for-ci
         run: npm test
 
-  # Build job - required for all branches that will be deployed
   build:
     name: ci/build
     runs-on: ubuntu-latest
-    # Run build check for all branches (dev, staging, main) to ensure preview deployments work
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - run: npm ci
 
-      - name: Generate Prisma Client
-        run: npx prisma generate
+      - run: npx prisma generate
 
       - name: Build application
         env:
@@ -103,93 +86,5 @@ jobs:
           GITHUB_CLIENT_SECRET: placeholder
         run: npm run build
 
-      - name: Check build output
-        run: |
-          if [ ! -d ".next" ]; then
-            echo "Build failed: .next directory not found"
-            exit 1
-          fi
-          echo "Build successful"
-
-  # Summary job for branch-specific requirements
-  status-check:
-    name: All Required Checks Passed
-    runs-on: ubuntu-latest
-    needs: [tests, build]
-    if: always()
-
-    steps:
-      - name: Check test results
-        if: needs.tests.result != 'success'
-        run: |
-          echo "Tests failed or were skipped"
-          exit 1
-
-      - name: Check build results
-        if: needs.build.result != 'success'
-        run: |
-          echo "Build failed or was skipped"
-          exit 1
-
-      - name: All checks passed
-        run: echo "All required checks passed successfully"
-
-  # Deploy to Vercel after CI passes
-  deploy:
-    name: Deploy to Vercel
-    runs-on: ubuntu-latest
-    needs: [status-check]
-    if: needs.status-check.result == 'success'
-    permissions:
-      contents: read
-      deployments: write
-      pull-requests: write
-      issues: write
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install Vercel CLI
-        run: npm install --global vercel@53.1.0
-
-      # Production deployment (push to main)
-      - name: Deploy to Vercel (Production)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-          vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-          vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
-
-      # Preview deployment (push to staging or dev, or any pull request)
-      - name: Deploy to Vercel (Preview)
-        id: vercel-preview
-        if: |
-          github.event_name == 'pull_request'
-          || (github.event_name == 'push' && (github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/dev'))
-        run: |
-          vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-          vercel build --token=${{ secrets.VERCEL_TOKEN }}
-          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
-          echo "url=$url" >> "$GITHUB_OUTPUT"
-          echo "Preview URL: $url"
-
-      - name: Comment preview URL on PR
-        if: github.event_name == 'pull_request' && steps.vercel-preview.outputs.url != ''
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: vercel-preview
-          message: |
-            🚀 **Preview deployment ready**
-
-            **URL:** ${{ steps.vercel-preview.outputs.url }}
-
-            _Updated for commit ${{ github.sha }}_
+      - name: Verify build output
+        run: test -d .next

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,38 +38,20 @@ Thank you for your interest in contributing! This document provides guidelines a
 
 ## Workflow Strategy
 
-This project follows a three-branch strategy:
+This project follows GitHub Flow: `main` is the only long-lived branch and represents production. All work happens in short-lived feature branches that merge back into `main` via pull request.
 
 ```
-dev (development) -> staging (pre-production) -> main (production)
+feature/x ─┐
+feature/y ─┼─► main (production)
+feature/z ─┘
 ```
-
-### Branch Descriptions
-
-- **`dev`**: Development branch for active feature work
-  - All feature branches are created from `dev`
-  - Merge feature branches back to `dev` when complete
-  - Deployed to development environment
-  - Less stable, frequent changes
-
-- **`staging`**: Pre-production testing branch
-  - Merge `dev` into `staging` when features are ready for testing
-  - Used for QA, integration testing, and final review
-  - Deployed to staging environment (Vercel preview)
-  - Should be stable and production-ready
-
-- **`main`**: Production branch
-  - Only merge `staging` into `main` after thorough testing
-  - Automatically deployed to production (blog.nullbyte.be)
-  - Must always be stable and working
-  - Protected branch with required reviews
 
 ### Workflow Steps
 
-1. **Create a feature branch from `dev`:**
+1. **Create a feature branch from `main`:**
    ```bash
-   git checkout dev
-   git pull upstream dev
+   git checkout main
+   git pull upstream main
    git checkout -b feature/your-feature-name
    ```
 
@@ -78,27 +60,20 @@ dev (development) -> staging (pre-production) -> main (production)
    - Write tests for new functionality
    - Ensure all tests pass locally
 
-3. **Push and create a Pull Request to `dev`:**
+3. **Push and open a Pull Request to `main`:**
    ```bash
    git push origin feature/your-feature-name
    ```
-   - Open a PR against the `dev` branch
-   - Fill out the PR template completely
-   - Request review from maintainers
+   - Vercel will post a preview deployment URL as a check on the PR.
+   - CI (`ci/tests`, `ci/build`) must pass before merge.
 
-4. **After PR is merged to `dev`:**
-   - Maintainers will test in the development environment
-   - When ready, `dev` is merged into `staging` for final testing
-
-5. **Staging to Production:**
-   - After thorough testing in staging, `staging` is merged into `main`
-   - This triggers automatic deployment to production
+4. **Merge to `main`:**
+   - Once approved and checks pass, the PR is merged.
+   - Vercel automatically deploys `main` to production.
 
 ### Branch Protection Rules
 
-- **`main`**: Requires PR approval, passing CI/CD, and no direct pushes
-- **`staging`**: Requires passing CI/CD
-- **`dev`**: Open for direct pushes from maintainers, but PRs encouraged
+- **`main`**: Requires PR (no direct pushes), passing `ci/tests` and `ci/build`, branch must be up to date before merge.
 
 ## Development Setup
 
@@ -316,10 +291,10 @@ describe('MyComponent', () => {
 
 1. **Ensure your branch is up to date:**
    ```bash
-   git checkout dev
-   git pull upstream dev
+   git checkout main
+   git pull upstream main
    git checkout your-feature-branch
-   git rebase dev
+   git rebase main
    ```
 
 2. **Run all checks locally:**
@@ -331,14 +306,14 @@ describe('MyComponent', () => {
 
 3. **Review your changes:**
    ```bash
-   git diff dev
+   git diff main
    ```
 
 ### PR Requirements
 
 Your PR must:
 
-- [ ] Target the `dev` branch (not `main` or `staging`)
+- [ ] Target the `main` branch
 - [ ] Pass all CI/CD checks (lint, test, build)
 - [ ] Include a clear description of changes
 - [ ] Reference any related issues
@@ -386,57 +361,31 @@ Any additional information reviewers should know.
 
 ## Deployment Pipeline
 
-### Automatic Deployments
-
-Our CI/CD pipeline automatically handles deployments:
+Deployments are handled by Vercel's native Git integration. CI runs as a gate (tests + build); Vercel does the actual deployments.
 
 ```mermaid
 graph LR
-    A[Push to dev] --> B[Run Tests]
-    B --> C[Deploy to Dev Environment]
-    D[Merge to staging] --> E[Run Tests]
-    E --> F[Deploy to Staging]
-    G[Merge to main] --> H[Run Tests]
-    H --> I[Deploy to Production]
+    A[Open PR] --> B[CI: tests + build]
+    A --> C[Vercel preview deployment]
+    B --> D[Merge to main]
+    C --> D
+    D --> E[Vercel deploys main to production]
 ```
 
 ### Environments
 
-| Environment | Branch | URL | Purpose |
-|------------|--------|-----|---------|
-| Development | `dev` | dev.nullbyte.be* | Active development |
-| Staging | `staging` | staging.nullbyte.be* | Pre-production testing |
-| Production | `main` | blog.nullbyte.be | Live site |
-
-*Note: Vercel preview URLs are used for dev and staging
-
-### Deployment Steps
-
-1. **Development**: Push to `dev` branch
-   - Runs automated tests
-   - Deploys to development environment
-   - Preview URL available in PR comments
-
-2. **Staging**: Merge `dev` into `staging`
-   - Runs full test suite
-   - Deploys to staging environment
-   - QA and final testing
-
-3. **Production**: Merge `staging` into `main`
-   - Requires approval
-   - Runs production build
-   - Runs database migrations
-   - Deploys to production
-   - Creates GitHub release
+| Environment | Trigger | URL |
+|------------|---------|-----|
+| Preview | Any PR | Vercel-generated preview URL (posted on the PR) |
+| Production | Push to `main` | blog.nullbyte.be |
 
 ### Rollback Strategy
 
 If issues are found in production:
 
-1. Revert the problematic PR in `main`
-2. Deploy the revert to production immediately
-3. Fix the issue in a new branch from `dev`
-4. Follow the normal workflow: dev -> staging -> main
+1. **Instant rollback**: In the Vercel dashboard, promote the previous successful production deployment. This takes effect in seconds and doesn't require a code change.
+2. **Code revert**: Open a PR that reverts the problematic commit on `main`. Once merged, Vercel deploys the revert.
+3. **Forward fix**: Open a new feature branch from `main`, fix the issue, and follow the normal PR workflow.
 
 ## Common Issues
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npm run vercel-build",
-  "git": {
-    "deploymentEnabled": {
-      "main": false,
-      "staging": false,
-      "dev": false
-    }
-  }
+  "buildCommand": "npm run vercel-build"
 }


### PR DESCRIPTION
Restrict CI to main (pushes and PRs) and streamline jobs: keep ci/tests and ci/build (with simplified checkout/setup/npm steps), remove in-workflow deployment, status-check and Vercel deploy logic, and add a simple build verification step. Update documentation to match the new GitHub Flow: .github/workflows/README.md and CONTRIBUTING.md now describe main as the single long-lived branch, PRs target main, and Vercel handles deployments (CI acts as a gate). Add tool-selection guidance to CLAUDE.md (prefer ChunkHound for code/semantic search). Also fix minor formatting in .mcp.json and simplify vercel.json to only declare the buildCommand.