### PR TITLE
fix(seo): Switch site name to NullByte and use nav strings

### DIFF
--- a/messages/en.ts
+++ b/messages/en.ts
@@ -220,7 +220,7 @@ const en: FullTranslation = {
     },
   },
   footer: {
-    techBlog: 'Tech Blog',
+    techBlog: 'NullByte',
     tagline: 'Sharing development journeys, insights, and discoveries in the world of technology.',
     quickLinks: 'Quick Links',
     home: 'Home',
@@ -228,10 +228,10 @@ const en: FullTranslation = {
     connect: 'Connect',
     email: 'Email',
     github: 'GitHub',
-    copyright: '© {year} Tech Blog. All rights reserved.',
+    copyright: '© {year} NullByte. All rights reserved.',
   },
   navigation: {
-    brand: 'Tech Blog',
+    brand: 'NullByte',
   },
   social: {
     share: 'Share:',

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -220,7 +220,7 @@ const fr: FullTranslation = {
     },
   },
   footer: {
-    techBlog: 'Blog Tech',
+    techBlog: 'NullByte',
     tagline: 'Partage de parcours de développement, d\'idées et de découvertes dans le monde de la technologie.',
     quickLinks: 'Liens Rapides',
     home: 'Accueil',
@@ -228,10 +228,10 @@ const fr: FullTranslation = {
     connect: 'Connexion',
     email: 'E-mail',
     github: 'GitHub',
-    copyright: '© {year} Blog Tech. Tous droits réservés.',
+    copyright: '© {year} NullByte. Tous droits réservés.',
   },
   navigation: {
-    brand: 'Blog Tech',
+    brand: 'NullByte',
   },
   social: {
     share: 'Partager :',

--- a/src/app/[locale]/(main)/page.tsx
+++ b/src/app/[locale]/(main)/page.tsx
@@ -12,9 +12,9 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params
   const t = await getTranslations({ locale, namespace: 'home' })
-  
+
   return {
-    title: t('title'),
+    title: { absolute: 'NullByte - Tech Blog' },
     description: t('subtitle'),
   }
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
     locale: 'en_US',
     url: getBaseUrl(),
     siteName: 'NullByte',
-    title: 'NullByte - Tech Blog',
+    title: 'NullByte',
     description: 'A modern tech blog sharing development insights, tutorials, and discoveries in software engineering.',
     images: [
       {
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'NullByte - Tech Blog',
+    title: 'NullByte',
     description: 'A modern tech blog sharing development insights, tutorials, and discoveries in software engineering.',
     images: ['/logo.png'],
   },

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -11,6 +11,7 @@ import { Role } from '@prisma/client'
 export default function Navigation() {
   const { data: session } = useSession()
   const t = useTranslations('common')
+  const tNav = useTranslations('navigation')
   const locale = useLocale()
 
   return (
@@ -23,7 +24,7 @@ export default function Navigation() {
         <div className="flex items-center justify-between h-16">
           <div className="flex items-center space-x-8">
             <Link href={`/${locale}`} className="text-xl font-bold" style={{ color: 'var(--text-primary)' }}>
-              {t('blog')}
+              {tNav('brand')}
             </Link>
             <div className="hidden md:flex space-x-4">
               <Link


### PR DESCRIPTION
Rename site branding to "NullByte" across translations and UI. Updated en.ts and fr.ts footer and navigation labels (techBlog, copyright, brand). Adjusted metadata: page title set to an absolute "NullByte - Tech Blog" and layout/twitter titles simplified to "NullByte". Navigation component now uses the 'navigation' translation namespace (tNav('brand')) instead of the common namespace. Minor whitespace/formatting cleanup in page.tsx.