### PR TITLE
chore(build): drop --turbopack from local production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build",
     "vercel-build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
next build --turbopack (still beta in 15.5) emits "Module N was instantiated... module factory is not available" runtime errors on post detail routes when serving the artifacts via next start. Vercel already runs plain next build via vercel-build, so this only fixes the local "npm run build && npm start" path. Dev still uses Turbopack.