### PR TITLE
fix(i18n): stop writing NEXT_LOCALE cookie on every response

### DIFF
--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -4,8 +4,11 @@ export const routing = defineRouting({
   locales: ['en', 'fr'],
   defaultLocale: 'en',
   localePrefix: 'always',
-  // Disabled so the i18n middleware stops setting the NEXT_LOCALE cookie on
-  // every response — that cookie is what forces dynamic rendering and prevents
-  // the edge from caching HTML. Visitors to "/" get redirected to defaultLocale.
-  localeDetection: false
+  // Disable Accept-Language / cookie sniffing at "/" so it redirects to
+  // defaultLocale without per-request branching. Locale comes from the URL.
+  localeDetection: false,
+  // Stop the middleware from writing NEXT_LOCALE on every response. The
+  // cookie added bytes to each response and prevents some proxies from
+  // caching Set-Cookie responses. Locale is in the URL — no cookie needed.
+  localeCookie: false
 });


### PR DESCRIPTION
localeDetection: false only disables reading the cookie for locale detection; next-intl still writes NEXT_LOCALE on every response via a separate localeCookie option. Set-Cookie added bytes to each response and risks proxy compatibility issues with cacheable HTML. Locale lives in the URL — no cookie needed.