### PR TITLE
fix(admin): case-insensitive tag/category resolve

### DIFF
--- a/src/app/api/admin/posts/[id]/route.ts
+++ b/src/app/api/admin/posts/[id]/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { requireAdmin, UnauthorizedError, ForbiddenError } from '@/lib/auth'
 import { ErrorCode, createErrorResponse } from '@/lib/errors'
-import { generateUniqueSlug, slugify } from '@/lib/slug'
+import { generateUniqueSlug } from '@/lib/slug'
+import { resolveCategoryIds, resolveTagIds } from '@/lib/post-relations'
 
 /**
  * GET /api/admin/posts/[id]
@@ -87,16 +88,15 @@ export async function PUT(
     // Generate unique slug from title (exclude current post from uniqueness check)
     const slug = await generateUniqueSlug(title, id)
 
-    // First, disconnect all existing tags and categories
-    await prisma.post.update({
-      where: { id },
-      data: {
-        tags: { set: [] },
-        categories: { set: [] }
-      }
-    })
+    // Resolve tag/category names to IDs first (case-insensitive on name, with
+    // slug fallback). Using `set: [...]` below replaces the post's relations
+    // in one update, so the previous "first disconnect all, then reconnect"
+    // two-step is unnecessary.
+    const [tagIds, categoryIds] = await Promise.all([
+      resolveTagIds(tags),
+      resolveCategoryIds(categories),
+    ])
 
-    // Then update with new data
     const updatedPost = await prisma.post.update({
       where: { id },
       data: {
@@ -107,24 +107,8 @@ export async function PUT(
         featuredImage: featuredImage || null,
         published,
         updatedAt: new Date(), // Manually set updatedAt on content changes
-        tags: {
-          connectOrCreate: tags?.map((tag: string) => ({
-            where: { slug: slugify(tag) },  // Use slug for lookup (case-insensitive)
-            create: {
-              name: tag,
-              slug: slugify(tag)
-            }
-          })) ?? []
-        },
-        categories: {
-          connectOrCreate: categories?.map((category: string) => ({
-            where: { slug: slugify(category) },  // Use slug for lookup (case-insensitive)
-            create: {
-              name: category,
-              slug: slugify(category)
-            }
-          })) ?? []
-        }
+        tags: { set: tagIds },
+        categories: { set: categoryIds },
       },
       include: {
         author: true,

--- a/src/app/api/admin/posts/route.ts
+++ b/src/app/api/admin/posts/route.ts
@@ -3,7 +3,8 @@ import { prisma } from '@/lib/prisma'
 import { requireAdmin, UnauthorizedError, ForbiddenError } from '@/lib/auth'
 import { calculateReadingTime } from '@/lib/reading-time'
 import { ErrorCode, createErrorResponse } from '@/lib/errors'
-import { generateUniqueSlug, slugify } from '@/lib/slug'
+import { generateUniqueSlug } from '@/lib/slug'
+import { resolveCategoryIds, resolveTagIds } from '@/lib/post-relations'
 
 /**
  * GET /api/admin/posts
@@ -126,6 +127,13 @@ export async function POST(request: NextRequest) {
     // Generate unique slug from title
     const slug = await generateUniqueSlug(title)
 
+    // Resolve tag/category names to IDs (case-insensitive on name, with slug
+    // fallback for legacy tags whose name and slug got out of sync).
+    const [tagIds, categoryIds] = await Promise.all([
+      resolveTagIds(tags),
+      resolveCategoryIds(categories),
+    ])
+
     const post = await prisma.post.create({
       data: {
         title,
@@ -135,24 +143,8 @@ export async function POST(request: NextRequest) {
         featuredImage: featuredImage || null,
         published: published ?? false,
         authorId: user.id,
-        tags: {
-          connectOrCreate: tags?.map((tag: string) => ({
-            where: { slug: slugify(tag) },  // Use slug for lookup (case-insensitive)
-            create: {
-              name: tag,
-              slug: slugify(tag)
-            }
-          })) ?? []
-        },
-        categories: {
-          connectOrCreate: categories?.map((category: string) => ({
-            where: { slug: slugify(category) },  // Use slug for lookup (case-insensitive)
-            create: {
-              name: category,
-              slug: slugify(category)
-            }
-          })) ?? []
-        }
+        tags: { connect: tagIds },
+        categories: { connect: categoryIds },
       },
       include: {
         author: true,

--- a/src/lib/post-relations.ts
+++ b/src/lib/post-relations.ts
@@ -1,0 +1,86 @@
+import 'server-only'
+
+import { prisma } from './prisma'
+import { slugify } from './slug'
+
+/**
+ * Resolve free-form tag names to existing-or-newly-created Tag IDs.
+ *
+ * Matching is case-insensitive on `name` AND falls back to `slug`. So:
+ * - "JavaScript", "javascript", "JAVASCRIPT" all map to the same tag.
+ * - Legacy tags whose `name` and `slug` got out of sync still get reused
+ *   instead of tripping a P2002 unique-constraint failure on `name`.
+ *
+ * Two-step (findFirst → create) instead of connectOrCreate because
+ * connectOrCreate's `where` only accepts a single unique field, not the
+ * OR predicate this normalization needs.
+ */
+export async function resolveTagIds(
+  names: string[] | undefined
+): Promise<{ id: string }[]> {
+  if (!names?.length) return []
+  const out: { id: string }[] = []
+  const seen = new Set<string>()
+  for (const raw of names) {
+    const name = raw.trim()
+    if (!name) continue
+    const slug = slugify(name)
+    if (!slug || seen.has(slug)) continue
+    seen.add(slug)
+
+    const existing = await prisma.tag.findFirst({
+      where: {
+        OR: [
+          { name: { equals: name, mode: 'insensitive' } },
+          { slug },
+        ],
+      },
+      select: { id: true },
+    })
+    if (existing) {
+      out.push({ id: existing.id })
+    } else {
+      const created = await prisma.tag.create({
+        data: { name, slug },
+        select: { id: true },
+      })
+      out.push({ id: created.id })
+    }
+  }
+  return out
+}
+
+export async function resolveCategoryIds(
+  names: string[] | undefined
+): Promise<{ id: string }[]> {
+  if (!names?.length) return []
+  const out: { id: string }[] = []
+  const seen = new Set<string>()
+  for (const raw of names) {
+    const name = raw.trim()
+    if (!name) continue
+    const slug = slugify(name)
+    if (!slug || seen.has(slug)) continue
+    seen.add(slug)
+
+    const existing = await prisma.category.findFirst({
+      where: {
+        OR: [
+          { name: { equals: name, mode: 'insensitive' } },
+          { slug },
+        ],
+      },
+      select: { id: true },
+    })
+    if (existing) {
+      out.push({ id: existing.id })
+    } else {
+      const created = await prisma.category.create({
+        data: { name, slug },
+        select: { id: true },
+      })
+      out.push({ id: created.id })
+    }
+  }
+  return out
+}


### PR DESCRIPTION
## Summary

- Saving a post via the admin editor would 500 with `PrismaClientKnownRequestError: Unique constraint failed on the fields: (name)` whenever an existing `Tag` had its `slug` and `name` out of sync (e.g. tag was renamed but slug never updated). The route's `connectOrCreate { where: { slug }, create: { name, slug } }` missed the existing row by slug, then the `create` branch tripped P2002 on the unique `name` index.
- Replaced with `resolveTagIds` / `resolveCategoryIds` helpers (`src/lib/post-relations.ts`) that do a `findFirst` with `OR: [{ name: { equals, mode: 'insensitive' } }, { slug }]`, then create only if no match. Restores the originally-intended case-insensitive matching ("JavaScript" / "javascript" / "JAVASCRIPT" → same tag) and is robust to legacy out-of-sync rows.
- Also drops the redundant "first disconnect, then reconnect" two-step in PUT — `tags: { set: ids }` replaces the post's relation in a single update.

## Why two-step instead of fixing connectOrCreate

`connectOrCreate.where` only accepts a single unique field; it can't take the OR predicate this normalization needs.

## Test plan

- [x] Edit an existing post in the admin and re-save it without changing tags — completes 200 (was 500 before)
- [x] Add a new tag with mixed casing (e.g. "JavaScript") to a post, save, then edit another post and add "javascript" — both posts share the same Tag row
- [x] Add a tag whose name matches an existing row but whose typed slug would differ — confirms the slug fallback still connects rather than creating a duplicate
- [x] Create a brand new tag — created with the typed casing preserved as `name` and the slugified form as `slug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)