### PR TITLE
chore: Remove @edge-csrf/nextjs and .npmrc workaround

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-# @edge-csrf/nextjs declares peer next@^13|^14|^15 and hasn't shipped Next 16 support.
-# Remove this once @edge-csrf/nextjs is replaced or publishes a Next 16-compatible release.
-legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@ai-sdk/react": "^2.0.28",
         "@ariakit/react": "^0.4.19",
         "@auth/prisma-adapter": "^2.11.0",
-        "@edge-csrf/nextjs": "^2.5.2",
         "@emoji-mart/data": "^1.2.1",
         "@faker-js/faker": "^9.9.0",
         "@fortawesome/fontawesome-svg-core": "^7.1.0",
@@ -1090,16 +1089,6 @@
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
       "license": "MIT"
-    },
-    "node_modules/@edge-csrf/nextjs": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@edge-csrf/nextjs/-/nextjs-2.5.2.tgz",
-      "integrity": "sha512-/LiV9jNp5WShOPG1B+Y4PJa5yCJSPCu/LjZ43Kqc+sNsPDaOSSMWF2GUI2JumII89+PEzzyF3V3aJzt8w6+CwQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "peerDependencies": {
-        "next": "^13.0.0 || ^14.0.0 || ^15.0.0"
-      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.5.0",
@@ -6567,9 +6556,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -7330,7 +7319,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7340,7 +7328,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -7680,6 +7667,113 @@
         "tailwind-merge": ">=2.2.0"
       }
     },
+    "node_modules/@udecode/plate": {
+      "version": "48.0.5",
+      "resolved": "https://registry.npmjs.org/@udecode/plate/-/plate-48.0.5.tgz",
+      "integrity": "sha512-C/Pi8a8xXVWqMj7lTaMD3/5oxW6Y0rJ7y2q2HsqU7fBTRF3kWw3+e0o1kjxXSzQnvTYsqVtEtmkPMiAv3Yaypg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@udecode/plate-core": "48.0.5",
+        "@udecode/plate-utils": "48.0.5",
+        "@udecode/react-hotkeys": "37.0.0",
+        "@udecode/react-utils": "47.3.1",
+        "@udecode/slate": "48.0.1",
+        "@udecode/utils": "47.2.7"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@udecode/plate-core": {
+      "version": "48.0.5",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-48.0.5.tgz",
+      "integrity": "sha512-Ep0/yISRWOOv2ZtSBjgnJ7wGKQZ2pqh+2xWxu7R2YqwbTk2Zteuuvassn7hGieaalti37ecyi9dIkUZZQL8uGg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@udecode/react-hotkeys": "37.0.0",
+        "@udecode/react-utils": "47.3.1",
+        "@udecode/slate": "48.0.1",
+        "@udecode/utils": "47.2.7",
+        "clsx": "^2.1.1",
+        "html-entities": "^2.6.0",
+        "is-hotkey": "^0.2.0",
+        "jotai": "~2.8.4",
+        "jotai-optics": "0.4.0",
+        "jotai-x": "2.3.2",
+        "lodash": "^4.17.21",
+        "nanoid": "^5.1.5",
+        "optics-ts": "2.4.1",
+        "slate-hyperscript": "0.100.0",
+        "slate-react": "0.114.2",
+        "use-deep-compare": "^1.3.0",
+        "zustand": "^5.0.3",
+        "zustand-x": "6.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@udecode/plate-core/node_modules/@udecode/react-utils": {
+      "version": "47.3.1",
+      "resolved": "https://registry.npmjs.org/@udecode/react-utils/-/react-utils-47.3.1.tgz",
+      "integrity": "sha512-fHnY0RGOeKKPnFW8xx8VWlLI0yscHd/kIU5t0bZ5bJ7Vanlhk1CUnPGDNa5HCIMVQrLARngGut/lIyGtoF65EQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@radix-ui/react-slot": "^1.2.0",
+        "@udecode/utils": "47.2.7",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@udecode/plate-core/node_modules/jotai": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.8.4.tgz",
+      "integrity": "sha512-f6jwjhBJcDtpeauT2xH01gnqadKEySwwt1qNBLvAXcnojkmb76EdqRt05Ym8IamfHGAQz2qMKAwftnyjeSoHAA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@udecode/plate-core/node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
     "node_modules/@udecode/plate-markdown": {
       "version": "48.0.2",
       "resolved": "https://registry.npmjs.org/@udecode/plate-markdown/-/plate-markdown-48.0.2.tgz",
@@ -7696,6 +7790,57 @@
       },
       "peerDependencies": {
         "@udecode/plate": ">=48.0.1",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@udecode/plate-utils": {
+      "version": "48.0.5",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-48.0.5.tgz",
+      "integrity": "sha512-GmSu5aidb0qtlABPlQMfiufJCmyGQIg+OqOSlP7l3OBqS3HG7+ixcHPQQi5HvEpBePbdt4fcOwUZBqdn46MohQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@udecode/plate-core": "48.0.5",
+        "@udecode/react-utils": "47.3.1",
+        "@udecode/slate": "48.0.1",
+        "@udecode/utils": "47.2.7",
+        "clsx": "^2.1.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@udecode/plate-utils/node_modules/@udecode/react-utils": {
+      "version": "47.3.1",
+      "resolved": "https://registry.npmjs.org/@udecode/react-utils/-/react-utils-47.3.1.tgz",
+      "integrity": "sha512-fHnY0RGOeKKPnFW8xx8VWlLI0yscHd/kIU5t0bZ5bJ7Vanlhk1CUnPGDNa5HCIMVQrLARngGut/lIyGtoF65EQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@radix-ui/react-slot": "^1.2.0",
+        "@udecode/utils": "47.2.7",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@udecode/plate/node_modules/@udecode/react-utils": {
+      "version": "47.3.1",
+      "resolved": "https://registry.npmjs.org/@udecode/react-utils/-/react-utils-47.3.1.tgz",
+      "integrity": "sha512-fHnY0RGOeKKPnFW8xx8VWlLI0yscHd/kIU5t0bZ5bJ7Vanlhk1CUnPGDNa5HCIMVQrLARngGut/lIyGtoF65EQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@radix-ui/react-slot": "^1.2.0",
+        "@udecode/utils": "47.2.7",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
       }
@@ -7723,6 +7868,51 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@udecode/slate": {
+      "version": "48.0.1",
+      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-48.0.1.tgz",
+      "integrity": "sha512-3so9oEvT5hisF9ZPFOmdeV8HDHC36uEDNYDq54cbExlIyQ1LG48ZRu/qbDMA/42aXmB2BJPIqa0PuQd2UYS3ig==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@udecode/utils": "47.2.7",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "slate": "0.114.0",
+        "slate-dom": "0.114.0"
+      }
+    },
+    "node_modules/@udecode/slate/node_modules/slate": {
+      "version": "0.114.0",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.114.0.tgz",
+      "integrity": "sha512-r3KHl22433DlN5BpLAlL4b3D8ItoGKAkj91YT6GhP39XuLoBT+YFd9ObKuL/okgiPb5lbwnW+71fM45hHceN9w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "immer": "^10.0.3",
+        "is-plain-object": "^5.0.0",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "node_modules/@udecode/slate/node_modules/slate-dom": {
+      "version": "0.114.0",
+      "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.114.0.tgz",
+      "integrity": "sha512-3LWIfiDPNQSY+SCPsvMTErCkx2gXTViLoWISisw6uM+unwiOkEF9ZmpHp88/SSmcq6k3P4aIquehUNeNUlkdiA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "slate": ">=0.99.0"
       }
     },
     "node_modules/@udecode/utils": {
@@ -9560,7 +9750,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-media-element": {
@@ -14451,6 +14640,26 @@
         "react": ">=17.0.0"
       }
     },
+    "node_modules/jotai-x": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/jotai-x/-/jotai-x-2.3.2.tgz",
+      "integrity": "sha512-WjOfSO4lZBtuy7igTcJ8ZMq9zf/MfjnJnMgsdLNLZrFeiaAWif7Kh/kXwIG4dFMLTOFZ9Bf96bztv21VBcTB0g==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "jotai": ">=2.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -17132,6 +17341,15 @@
       "integrity": "sha512-jHKGij7NoYccy2y54+e/wHVMoRgNt4h/Kn0XS9c4GbKu3KgJyANLUN8sFcDixv6sqz4V2kh6CTWgrkIidQksUg==",
       "license": "MIT"
     },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -19591,6 +19809,41 @@
         "slate": ">=0.99.0"
       }
     },
+    "node_modules/slate-hyperscript": {
+      "version": "0.100.0",
+      "resolved": "https://registry.npmjs.org/slate-hyperscript/-/slate-hyperscript-0.100.0.tgz",
+      "integrity": "sha512-fb2KdAYg6RkrQGlqaIi4wdqz3oa0S4zKNBJlbnJbNOwa23+9FLD6oPVx9zUGqCSIpy+HIpOeqXrg0Kzwh/Ii4A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-plain-object": "^5.0.0"
+      },
+      "peerDependencies": {
+        "slate": ">=0.65.3"
+      }
+    },
+    "node_modules/slate-react": {
+      "version": "0.114.2",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.114.2.tgz",
+      "integrity": "sha512-yqJnX1/7A30szl9BxW3qX99MZy6mM6VtUi1rXTy0JpRMTKv3rduo0WOxqcX90tpt0ke2pzHGbrLLr1buIN4vrw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "slate": ">=0.114.0",
+        "slate-dom": ">=0.110.2"
+      }
+    },
     "node_modules/sliced": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
@@ -20204,7 +20457,6 @@
       "version": "4.1.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
       "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -20857,7 +21109,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -22152,6 +22404,33 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zustand-x": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zustand-x/-/zustand-x-6.1.0.tgz",
+      "integrity": "sha512-lW1Fs29bLCrerWDa3lZLPuEn+ZkbSGzXdwdImKLJUtI2OqlDjpcFac5WTzCPs2ul/igwXFnGiKH1mdn+1Pl2mw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "immer": "^10.0.3",
+        "lodash.mapvalues": "^4.6.0",
+        "mutative": "1.1.0",
+        "react-tracked": "^1.7.11",
+        "use-sync-external-store": "1.4.0"
+      },
+      "peerDependencies": {
+        "zustand": ">=5.0.2"
+      }
+    },
+    "node_modules/zustand-x/node_modules/use-sync-external-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@ai-sdk/react": "^2.0.28",
     "@ariakit/react": "^0.4.19",
     "@auth/prisma-adapter": "^2.11.0",
-    "@edge-csrf/nextjs": "^2.5.2",
     "@emoji-mart/data": "^1.2.1",
     "@faker-js/faker": "^9.9.0",
     "@fortawesome/fontawesome-svg-core": "^7.1.0",


### PR DESCRIPTION
Delete the .npmrc workaround (legacy-peer-deps=true) and remove @edge-csrf/nextjs from package.json. package-lock.json was updated to reflect the removed dependency and resulting dependency tree changes.