### PR TITLE
Remove bare-domain x-default sitemap entry

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -72,15 +72,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   })
 
-  // Bare-domain entry pointing at the default-locale homepage via x-default
-  const root: MetadataRoute.Sitemap = [{
-    url: baseUrl,
-    lastModified: mostRecentPostDate,
-    changeFrequency: 'daily' as const,
-    priority: 1,
-    alternates: { languages: languageAlternates('') },
-  }]
-
   // Homepage - create entry for each locale with alternates
   const homepage: MetadataRoute.Sitemap = locales.map((locale) => ({
     url: `${baseUrl}/${locale}`,
@@ -132,5 +123,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }))
   )
 
-  return [...root, ...homepage, ...postsPage, ...postPages, ...tagPages, ...categoryPages]
+  return [...homepage, ...postsPage, ...postPages, ...tagPages, ...categoryPages]
 }


### PR DESCRIPTION
Remove the root (bare-domain) sitemap entry that pointed to the default-locale homepage via x-default and adjusted the returned sitemap to exclude that root entry. The sitemap now only includes locale-specific homepage entries (with alternates), posts, post pages, tag pages, and category pages.