### PR TITLE
fix(seo): stop blocking /_next/* in robots.txt

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -9,7 +9,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/admin', '/api', '/_next/*'],
+        disallow: ['/admin', '/api'],
       },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,


### PR DESCRIPTION
Allow crawlers to fetch JS/CSS bundles under /_next/static so Googlebot can fully render pages. Blocking them prevented rendering and triggered 1078 "blocked internal resource" warnings; keep /admin and /api disallowed.